### PR TITLE
Support newer foreman start syntax

### DIFF
--- a/bowler.gemspec
+++ b/bowler.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables        = %w(bowl)
   s.require_paths      = ["lib"]
 
-  s.add_dependency 'foreman'
+  s.add_dependency 'foreman', '>= 0.35.0'
 
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rspec', '~> 2.8.0'

--- a/lib/bowler/dependency_tree.rb
+++ b/lib/bowler/dependency_tree.rb
@@ -21,10 +21,7 @@ module Bowler
     end
 
     def process_list_for(processes)
-      on = dependencies_for(processes)
-      off = @definition.processes - on
-
-      [ on.map {|x| "#{x}=1" }, off.map {|x| "#{x}=0" } ].flatten.sort.join(',')
+      dependencies_for(processes).map {|x| "#{x}=1" }.sort.join(',')
     end
 
   end

--- a/spec/dependency_tree_spec.rb
+++ b/spec/dependency_tree_spec.rb
@@ -39,7 +39,7 @@ module Bowler
       end
 
       it "should give a correct process list" do
-        @tree.process_list_for([:app2]).should == "a=0,app1=0,app2=1,app3=1,b=0,c=0,other=0"
+        @tree.process_list_for([:app2]).should == "app2=1,app3=1"
       end
     end
 
@@ -53,7 +53,7 @@ module Bowler
       end
 
       it "should give a correct process list" do
-        @tree.process_list_for([:app2, :other]).should == "a=1,app1=0,app2=1,app3=1,b=1,c=1,other=1"
+        @tree.process_list_for([:app2, :other]).should == "a=1,app2=1,app3=1,b=1,c=1,other=1"
       end
     end
 


### PR DESCRIPTION
Since 0.35.0, foreman defaults to a concurrency of zero when specifying
concurrency options (https://github.com/ddollar/foreman/pull/132).

Depending on a newer version than this menas that it no longer matters
if entries are added to the Procfile, but not to the Pinfile. This also
allows more of the processes to have coloured output.
