### PR TITLE
Raise error when encountering an unknown process

### DIFF
--- a/lib/bowler/dependency_tree.rb
+++ b/lib/bowler/dependency_tree.rb
@@ -16,6 +16,10 @@ module Bowler
     def dependencies_for(processes, visited = [])
       return [] unless processes
       (processes - visited).map { |p|
+        unless @definition.processes.include?(p)
+          raise PinfileError, "process #{p} not found"
+        end
+
         [dependencies_for(@definition.tree[p], visited + [p]), p]
       }.flatten.compact.uniq
     end

--- a/spec/dependency_tree_spec.rb
+++ b/spec/dependency_tree_spec.rb
@@ -16,6 +16,14 @@ module Bowler
         tree.dependencies_for([:nyan]).should =~ [:bar, :foo, :nyan, :required]
       end
 
+      it "should raise when encountering unknown dependencies" do
+        tree = DependencyTree.load File.join( File.dirname(__FILE__), 'fixtures', 'dependency_tree_pinfile' )
+
+        expect {
+          tree.dependencies_for([:not_a_dependency])
+        }.to raise_error(PinfileError)
+      end
+
       it "should find the dependencies of dependencies" do
         tree = DependencyTree.load File.join( File.dirname(__FILE__), 'fixtures', 'dependency_tree_pinfile' )
 


### PR DESCRIPTION
Hi Jordan!

Currently bowler will not complain when you try to run a process that isn't defined in the Pinfile. This is sometimes confusing, as other processes might mask the fact that you misspelled a process name.

For example:

<img width="1237" alt="screen shot 2015-10-22 at 23 17 14" src="https://cloud.githubusercontent.com/assets/233676/10679849/138e4352-7913-11e5-9fd4-c506cfc3dd9e.png">

From the output it isn't clear that `content-api` isn't running (because it should be _contentapi_).

This commit verifies that the process exist. If it doesn't, an error will be displayed:

<img width="1237" alt="screen shot 2015-10-22 at 23 18 42" src="https://cloud.githubusercontent.com/assets/233676/10679881/45ab9e52-7913-11e5-943e-fad95f0fe131.png">
