### PR TITLE
Use three dots not two after the list of 'starting' processes

### DIFF
--- a/lib/bowler/cli.rb
+++ b/lib/bowler/cli.rb
@@ -30,7 +30,7 @@ module Bowler
 
       tree = Bowler::DependencyTree.load
       to_launch = tree.dependencies_for(processes) - options[:without]
-      logger.info "Starting #{to_launch.join(', ')}.."
+      logger.info "Starting #{to_launch.join(', ')}..."
 
       start_foreman_with( launch_string(to_launch) )
     rescue PinfileNotFound


### PR DESCRIPTION
- After using this for coming up to two years now, I've just noticed
  this and it's going to keep annoying me if I don't fix it. You know
  what my brain is like!
- Corrected to use three dots because "Starting" is ongoing - you're
  waiting for things to happen.

:sunny: