### PR TITLE
Add --output-only

### DIFF
--- a/lib/bowler/cli.rb
+++ b/lib/bowler/cli.rb
@@ -15,6 +15,10 @@ module Bowler
           options[:without] << process.to_sym
         end
 
+        opts.on_tail('-o', '--output-only', 'Output the apps to be started') do
+          options[:output_only] = true
+        end
+
         opts.on_tail("-h", "--help", "Show this message") do
           puts opts
           exit
@@ -30,9 +34,13 @@ module Bowler
 
       tree = Bowler::DependencyTree.load
       to_launch = tree.dependencies_for(processes) - options[:without]
-      logger.info "Starting #{to_launch.join(', ')}..."
 
-      start_foreman_with( launch_string(to_launch) )
+      if options[:output_only]
+        puts to_launch.join("\n")
+      else
+        logger.info "Starting #{to_launch.join(', ')}..."
+        start_foreman_with( launch_string(to_launch) )
+      end
     rescue PinfileNotFound
       logger.error "Bowler could not find a Pinfile in the current directory."
     rescue PinfileError => e

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -61,6 +61,16 @@ module Bowler
       end
     end
 
+    context 'with --output-only flag' do
+      it 'outputs the apps to be run' do
+        stub_dependency_tree(:myapp, :myapp2)
+
+        STDOUT.expects(:puts).with("myapp\nmyapp2")
+
+        CLI.start(['myapp', 'myapp2', '--output-only'])
+      end
+    end
+
     it 'starts foreman with the provided processes' do
       stub_dependency_tree(:a, :b)
 


### PR DESCRIPTION
This flag will make Bowler just output the apps that will be run for a command.

For example:

```
vagrant@development:~/govuk/development$ bowl collections --output-only
static
content-store
router-api
collections
... (omitted)
```

This allows us to build other scripts that depend on the output. In particular, we're working on a little script that automatically clones all dependencies for an application. This will make onboarding new developers on a large project a bit easier.