### PR TITLE
Generate graph of dependencies

### DIFF
--- a/bowler.gemspec
+++ b/bowler.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths      = ["lib"]
 
   s.add_dependency 'foreman', '>= 0.35.0'
+  s.add_dependency 'ruby-graphviz', '~> 1.2.2'
 
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rspec-core', '~> 2.14.7'

--- a/lib/bowler/dependency_tree.rb
+++ b/lib/bowler/dependency_tree.rb
@@ -1,3 +1,5 @@
+require 'graphviz'
+
 module Bowler
 
   class DependencyTree
@@ -22,6 +24,21 @@ module Bowler
 
         [dependencies_for(@definition.tree[p], visited + [p]), p]
       }.flatten.compact.uniq
+    end
+
+    def graph
+      g = GraphViz.new(:G, :type => :digraph)
+
+      @definition.processes.each do |process|
+        g.add_nodes(process.to_s)
+
+        dependencies = tree.dependencies_for([process]) - [process]
+        dependencies.each do |dependency|
+          g.add_edges(process.to_s, dependency.to_s)
+        end
+      end
+
+      g.to_s
     end
 
   end


### PR DESCRIPTION
This commit generates a graph of app dependencies as a dot file.

Is this something you'd be interested in merging? Totally understand if you want to keep the codebase small and not dependent on Graphviz.

If it is something you'd merge, I can write a test for it.
